### PR TITLE
Set MEDIA_ROOT to "/tmp/" to not get poluted by testing

### DIFF
--- a/datagen/config/settings/test.py
+++ b/datagen/config/settings/test.py
@@ -5,3 +5,5 @@ from .local_docker import *
 CELERY_BROKER = "pyamqp://@localhost/testing"
 
 TEMPLATES[0]["OPTIONS"]["debug"] = True  # For templates coverage plugin
+
+MEDIA_ROOT = "/tmp/testmedia/"


### PR DESCRIPTION
Signed-off-by: Ivan Omelchenko <zver2010-3@ya.ru>